### PR TITLE
Make resizeable. Fix button.

### DIFF
--- a/emesary-damage-system/gui-dialogs/event-log.xml
+++ b/emesary-damage-system/gui-dialogs/event-log.xml
@@ -46,8 +46,10 @@
     </nasal>
 	
 	<button>
-		<!--<x>0</x>
-		<y>0</y>-->
+                <valign>top</valign>
+                <pref-width>90</pref-width>
+                <pref-height>20</pref-height>
+                <border>2</border>
 		<legend>Refresh</legend>
 		<binding>
 			<command>nasal</command>
@@ -72,9 +74,10 @@
 	</text>
 
 	<textbox>
-	    <!-- position -->
-	    <!--<x>100</x>
-	    <y>100</y>-->
+            <!-- Makes window content resizeable. -->
+            <halign>fill</halign>
+            <valign>fill</valign>
+            <stretch>true</stretch>>
 
 	    <!-- dimensions -->
 	    <pref-width>500</pref-width>


### PR DESCRIPTION
Prior to this commit the button wandering around when resizing the window, now it stays centred and at the top of the page.
Also, now the text area is fully resizeable with the window it is in.

Before
![fgfs-20210512213425](https://user-images.githubusercontent.com/6201512/118047237-652ca380-b372-11eb-86aa-81f7020c0a40.png)

After
![fgfs-20210512213522](https://user-images.githubusercontent.com/6201512/118047246-68c02a80-b372-11eb-8f9b-6aad292b8793.png)
