### PR TITLE
Minor visual and code quality changes to event log

### DIFF
--- a/emesary-damage-system/gui-dialogs/event-log.xml
+++ b/emesary-damage-system/gui-dialogs/event-log.xml
@@ -50,7 +50,6 @@
 	<button>
                 <valign>top</valign>
                 <pref-width>90</pref-width>
-                <pref-height>20</pref-height>
                 <border>2</border>
 		<legend>Refresh</legend>
 		<binding>

--- a/emesary-damage-system/gui-dialogs/event-log.xml
+++ b/emesary-damage-system/gui-dialogs/event-log.xml
@@ -80,7 +80,7 @@
             <!-- Makes window content resizeable. -->
             <halign>fill</halign>
             <valign>fill</valign>
-            <stretch>true</stretch>>
+            <stretch>true</stretch>
 
 	    <!-- dimensions -->
 	    <pref-width>500</pref-width>

--- a/emesary-damage-system/gui-dialogs/event-log.xml
+++ b/emesary-damage-system/gui-dialogs/event-log.xml
@@ -93,7 +93,4 @@
 	    <top-line>0</top-line> <!-- line to show at top, -ve numbers show last line -->
 	    <editable>false</editable> <!-- if the puLargeInput is supposed to be editable -->
 	</textbox>
-
-	<empty><stretch>1</stretch></empty>
-	
 </PropertyList>

--- a/emesary-damage-system/gui-dialogs/event-log.xml
+++ b/emesary-damage-system/gui-dialogs/event-log.xml
@@ -37,12 +37,12 @@
 	<nasal>
         <open>
             <![CDATA[
-                setprop("sim/model/mig21/event-log", "Click refresh to see the combat event log..");
+                setprop("sim/gui/dialogs/flightlog/buffer", "Click refresh to see the combat event log..");
             ]]>
         </open>
         <close>
         	<![CDATA[
-                setprop("sim/model/mig21/event-log", "");
+                setprop("sim/gui/dialogs/flightlog/buffer", "");
             ]]>
         </close>
     </nasal>
@@ -66,7 +66,7 @@
 				} else {
 					str = "The aircraft must be still to read the combat event log.";
 				}
-				setprop("sim/model/mig21/event-log", str);
+				setprop("sim/gui/dialogs/flightlog/buffer", str);
 			]]></script>
 		</binding>
 	</button>
@@ -86,7 +86,7 @@
 	    <pref-width>500</pref-width>
 		<pref-height>500</pref-height>
 
-	    <property>/sim/model/mig21/event-log</property>
+	    <property>/sim/gui/dialogs/flightlog/buffer</property>
 		<live>true</live>
 	    <slider>15</slider> <!--width for slider -->
 	    <wrap>false</wrap> <!-- don't wrap text; default: true -->

--- a/emesary-damage-system/gui-dialogs/event-log.xml
+++ b/emesary-damage-system/gui-dialogs/event-log.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <PropertyList>
 	<name>flightlog</name>
-  	<modal>false</modal>
-  	<layout>vbox</layout>
-  	<draggable>true</draggable>
-    <resizable>true</resizable>
+	<modal>false</modal>
+	<layout>vbox</layout>
+	<draggable>true</draggable>
+	<resizable>true</resizable>
 
-    <group>
+	<group>
 		<layout>hbox</layout>
 		<empty><stretch>1</stretch></empty>
 
@@ -33,63 +33,63 @@
 	</group>
 
 	<hrule/>
-	
+
 	<nasal>
-        <open>
-            <![CDATA[
-                setprop("sim/gui/dialogs/flightlog/buffer", "Click refresh to see the combat event log..");
-            ]]>
-        </open>
-        <close>
-        	<![CDATA[
-                setprop("sim/gui/dialogs/flightlog/buffer", "");
-            ]]>
-        </close>
-    </nasal>
-	
+		<open>
+			<![CDATA[
+				setprop("sim/gui/dialogs/flightlog/buffer", "Click refresh to see the combat event log..");
+			]]>
+		</open>
+		<close>
+			<![CDATA[
+				setprop("sim/gui/dialogs/flightlog/buffer", "");
+			]]>
+		</close>
+	</nasal>
+
 	<button>
-                <valign>top</valign>
-                <pref-width>90</pref-width>
-                <border>2</border>
+		<valign>top</valign>
+		<pref-width>90</pref-width>
+		<border>2</border>
 		<legend>Refresh</legend>
 		<binding>
 			<command>nasal</command>
 			<script><![CDATA[
 				var str = "";
 				if (getprop("velocities/groundspeed-kt") < 10) {
-				  var buffer = damage.damageLog.get_buffer();
-				  
-				  foreach(entry; buffer) {
-				      str = str~""~entry.time~" "~entry.message~"\n";
-				  }
+					var buffer = damage.damageLog.get_buffer();
+
+					foreach(entry; buffer) {
+						str = str~""~entry.time~" "~entry.message~"\n";
+					}
 				} else {
 					str = "The aircraft must be still to read the combat event log.";
 				}
 				setprop("sim/gui/dialogs/flightlog/buffer", str);
-			]]></script>
+				]]></script>
 		</binding>
 	</button>
 
-  	<text>
-  		<halign>left</halign>
-	    <label>Event log:</label>
+	<text>
+		<halign>left</halign>
+		<label>Event log:</label>
 	</text>
 
 	<textbox>
-            <!-- Makes window content resizeable. -->
-            <halign>fill</halign>
-            <valign>fill</valign>
-            <stretch>true</stretch>
+		<!-- Makes window content resizeable. -->
+		<halign>fill</halign>
+		<valign>fill</valign>
+		<stretch>true</stretch>
 
-	    <!-- dimensions -->
-	    <pref-width>500</pref-width>
+			<!-- dimensions -->
+		<pref-width>500</pref-width>
 		<pref-height>500</pref-height>
 
-	    <property>/sim/gui/dialogs/flightlog/buffer</property>
+		<property>/sim/gui/dialogs/flightlog/buffer</property>
 		<live>true</live>
-	    <slider>15</slider> <!--width for slider -->
-	    <wrap>false</wrap> <!-- don't wrap text; default: true -->
-	    <top-line>0</top-line> <!-- line to show at top, -ve numbers show last line -->
-	    <editable>false</editable> <!-- if the puLargeInput is supposed to be editable -->
+		<slider>15</slider> <!--width for slider -->
+		<wrap>false</wrap> <!-- don't wrap text; default: true -->
+		<top-line>0</top-line> <!-- line to show at top, -ve numbers show last line -->
+		<editable>false</editable> <!-- if the puLargeInput is supposed to be editable -->
 	</textbox>
 </PropertyList>


### PR DESCRIPTION
Visual changes:
- remove bottom space, which grows when resizing the dialog
- increase refresh button height to standard height for PLIB dialogs

Code quality:
- a (dangerous) `>` typo
- indentation
- use a property in `/sim/gui/dialogs` (which is a standard path for dialogs) for the buffer, and remove `mig21` from its path.