### PR TITLE
Ground assets RCS

### DIFF
--- a/radar/rcs.txt
+++ b/radar/rcs.txt
@@ -86,6 +86,23 @@ var rcs_oprf_database = {
 };
 
 
+var ground_assets = ["depot", "ZSU-23-4M", "buk-m2", "S-75", "s-300", "MIM104D", "truck", "tower", "gci", "struct", "point", "hunter"];
+
+### Amend table rcs_oprf_database to use real instead of reduced ground assets RCS values.
+#
+# Ground assets have very low RCS values.
+# This is to simulate ground clutter making them very hard to spot on radar.
+# Radars which themselves simulate ground clutter (e.g. a proper ground radar)
+# may however want to use the real RCS values (without this reduction).
+# They should call this function at initialisation to do so.
+#
+var use_real_ground_RCS = func {
+    foreach (var asset; ground_assets) {
+        rcs_oprf_database[asset] *= 100;
+    }
+}
+
+
 RADARS:
 =======
 JA37       40 3.2     PS 46/A

--- a/radar/rcs.txt
+++ b/radar/rcs.txt
@@ -1,6 +1,6 @@
 
 var rcs_oprf_database = {
-    #Revision MAY 05 2021
+    #Revision SEP 03 2022
     # This list contains the mandatory RCS frontal values for OPRF (anno 1997), feel free to add non-OPRF to your aircraft, we don't care.
     "default":                  150,    #default value if target's model isn't listed
     "f-14b":                    12,     
@@ -60,20 +60,20 @@ var rcs_oprf_database = {
     "tigre":                    6,      #guess, Hunter
 # OPRF assets:
 # Notice that the non-SEA of these have been very reduced to simulate hard to find in ground clutter
-    "depot":                    0.20,
+    "depot":                    1,
     "ZSU-23-4M":                0.04,
     "buk-m2":                   0.08,
     "S-75":                     0.12,
     "s-300":                    0.16,
     "MIM104D":                  0.15,
-    "truck":                    0.15,
+    "truck":                    0.02,
     "missile_frigate":          450, 
     "frigate":                  450,
     "tower":                    0.25,   #gone
     "gci":                      0.50,
-    "struct":                   0.20,   
+    "struct":                   1,
     "rig":                      500,
-    "point":                    0.14,
+    "point":                    0.7,
     "hunter":                   0.10,    #sea assets, Hunter
 # Automats:
     "MiG-29":                   6,


### PR DESCRIPTION
Here's my "solution" for what we discussed regarding the AJS radar and ground assets RCS. It's a function to call at initialization to amend the table. Other aircrafts don't require any modification.

There's also changes to a couple of odd RCS values (decrease for trucks, increase for buildings), see first commit message. The buildings RCS ends up at 1m^2, same as small aircrafts (mirage / drones). Is that reasonable?