### PR TITLE
Add 3M9 missile to warheads db

### DIFF
--- a/emesary-damage-system/nasal/damage.nas
+++ b/emesary-damage-system/nasal/damage.nas
@@ -164,6 +164,7 @@ var warheads = {
     "pilot":             [93,    0.00,1,0],# ejected pilot
     "BETAB-500ShP":      [94, 1160.00,1,0],
     "Flare":             [95,    0.00,0,0],
+    "3M9":               [96,  125.00,0,0],# 3M9 Missile used with 2K12/SA-6
 };
 
 var AIR_RADAR = "air";
@@ -187,6 +188,7 @@ var radar_signatures = {
                 "E-8R":                     AIR_RADAR,
                 "EC-137D":                  AIR_RADAR,
                 "Mig-28":                   AIR_RADAR,
+                "2K12":                     AIR_RADAR,#Air radar tone chosen so that there is at least some lock tone until asset-specific is created
                 "ZSU-23-4M":                "gnd-23",
                 "S-75":                     "gnd-02",
                 "buk-m2":                   "gnd-11",
@@ -200,7 +202,7 @@ var radar_signatures = {
 var id2warhead = [];
 var launched = {};# callsign: elapsed-sec
 var approached = {};# callsign: uniqueID
-var heavy_smoke = [61,62,63,65,92];
+var heavy_smoke = [61,62,63,65,92,96];
 
 var k = keys(warheads);
 


### PR DESCRIPTION
Added 3M9 missile used with 2K12 to warheads db. AIR_RADAR chosen so that there is some form of sound until a more suitable tone is created for asset. Not added to rcs db due to the fact it is not an OPRF Approved asset.