### PR TITLE
Add tacview recorder

### DIFF
--- a/emesary-damage-system/nasal/missile-code.nas
+++ b/emesary-damage-system/nasal/missile-code.nas
@@ -253,7 +253,7 @@ var AIM = {
         	m.SwSoundVol.setDoubleValue(0);
         }
         m.inacc                 = getprop("payload/armament/tgp-inacc-system");# set to false, unless using the f16
-        m.tacview_support       = getprop("payload/armament/tacview");# set to false, unless using an aircraft that has tacview
+        m.tacview_support       = getprop("payload/d-config/tacview_supported");# set to false, unless using an aircraft that has tacview
         m.gnd_launch            = getprop("payload/armament/gnd-launch");#true to be a SAM or ship
         if (m.gnd_launch == nil) {
         	m.gnd_launch = 0;

--- a/libraries/tacview.nas
+++ b/libraries/tacview.nas
@@ -1,0 +1,358 @@
+# author: pinto
+# adapted by Nikolai V. Chr.
+
+var main_update_rate = 0.3;
+var write_rate = 10;
+
+var outstr = "";
+
+var timestamp = "";
+var output_file = "";
+var f = "";
+var myplaneID = int(rand()*10000);
+var starttime = 0;
+var writetime = 0;
+
+seen_ids = [];
+
+var tacobj = {
+    tacviewID: 0,
+    lat: 0,
+    lon: 0,
+    alt: 0,
+    roll: 0,
+    pitch: 0,
+    heading: 0,
+    speed: -1,
+    valid: 0,
+};
+
+var lat = 0;
+var lon = 0;
+var alt = 0;
+var roll = 0;
+var pitch = 0;
+var heading = 0;
+var speed = 0;
+var mutexWrite = thread.newlock();
+
+var startwrite = func() {
+    timestamp = getprop("/sim/time/utc/year") ~ "-" ~ getprop("/sim/time/utc/month") ~ "-" ~ getprop("/sim/time/utc/day") ~ "T";
+    timestamp = timestamp ~ getprop("/sim/time/utc/hour") ~ ":" ~ getprop("/sim/time/utc/minute") ~ ":" ~ getprop("/sim/time/utc/second") ~ "Z";
+    filetimestamp = string.replace(timestamp,":","-");
+    output_file = getprop("/sim/fg-home") ~ "/Export/tacview-f16-" ~ filetimestamp ~ ".acmi";
+    # create the file
+    f = io.open(output_file, "w");
+    io.close(f);
+    var ownship = "F-16C";
+    if (getprop("sim/variant-id")<3) {
+        ownship = "F-16A";
+    }
+    var color = ",Color=Blue";
+    if (left(getprop("sim/multiplay/callsign"),5)=="OPFOR") {
+        color=",Color=Red";
+    }
+    var meta = sprintf(",DataSource=FlightGear %s,DataRecorder=%s v%s", getprop("sim/version/flightgear"), getprop("sim/description"), getprop("sim/aircraft-version"));
+    thread.lock(mutexWrite);
+    write("FileType=text/acmi/tacview\nFileVersion=2.1\n");
+    write("0,ReferenceTime=" ~ timestamp ~ meta ~ "\n#0\n");
+    write(myplaneID ~ ",T=" ~ getLon() ~ "|" ~ getLat() ~ "|" ~ getAlt() ~ "|" ~ getRoll() ~ "|" ~ getPitch() ~ "|" ~ getHeading() ~ ",Name="~ownship~",CallSign="~getprop("/sim/multiplay/callsign")~color~"\n"); #
+    thread.unlock(mutexWrite);
+    starttime = systime();
+    setprop("/sim/screen/black","Starting Tacview recording");
+    settimer(func(){mainloop();}, main_update_rate);
+}
+
+var stopwrite = func() {
+    setprop("/sim/screen/black","Stopping Tacview recording");
+    writetofile();
+    starttime = 0;
+    seen_ids = [];
+    explo_arr = [];
+    explosion_timeout_loop(1);
+}
+
+var mainloop = func() {
+    if (!starttime) {
+        return;
+    }
+    settimer(func(){mainloop();}, main_update_rate);
+    if (systime() - writetime > write_rate) {
+        writetofile();
+    }
+    thread.lock(mutexWrite);
+    write("#" ~ (systime() - starttime)~"\n");
+    thread.unlock(mutexWrite);
+    writeMyPlanePos();
+    writeMyPlaneAttributes();
+    foreach (var cx; radar_system.getCompleteList()) {
+        if(cx.getType() == armament.ORDNANCE) {
+            continue;
+        }
+        if (cx["prop"] != nil and cx.prop.getName() == "multiplayer" and getprop("sim/multiplay/txhost") == "mpserver.opredflag.com") {
+            continue;
+        }
+        var color = ",Color=Blue";
+        if (left(cx.get_Callsign(),5)=="OPFOR" or left(cx.get_Callsign(),4)=="OPFR") {
+            color=",Color=Red";
+        }
+        thread.lock(mutexWrite);
+        if (find_in_array(seen_ids, cx.tacobj.tacviewID) == -1) {
+            append(seen_ids, cx.tacobj.tacviewID);
+            var model_is = cx.getModel();
+            if (model_is=="Mig-28") {
+                model_is = "F-16C";
+                color=",Color=Red";
+            }
+            write(cx.tacobj.tacviewID ~ ",Name="~ model_is~ ",CallSign=" ~ cx.get_Callsign() ~color~"\n")
+        }
+        if (cx.tacobj.valid) {
+            var cxC = cx.getCoord();
+            lon = cxC.lon();
+            lat = cxC.lat();
+            alt = cxC.alt();
+            roll = cx.get_Roll();
+            pitch = cx.get_Pitch();
+            heading = cx.get_heading();
+            speed = cx.get_Speed()*KT2MPS;
+
+            write(cx.tacobj.tacviewID ~ ",T=");
+            if (lon != cx.tacobj.lon) {
+                write(sprintf("%.6f",lon));
+                cx.tacobj.lon = lon;
+            }
+            write("|");
+            if (lat != cx.tacobj.lat) {
+                write(sprintf("%.6f",lat));
+                cx.tacobj.lat = lat;
+            }
+            write("|");
+            if (alt != cx.tacobj.alt) {
+                write(sprintf("%.1f",alt));
+                cx.tacobj.alt = alt;
+            }
+            write("|");
+            if (roll != cx.tacobj.roll) {
+                write(sprintf("%.1f",roll));
+                cx.tacobj.roll = roll;
+            }
+            write("|");
+            if (pitch != cx.tacobj.pitch) {
+                write(sprintf("%.1f",pitch));
+                cx.tacobj.pitch = pitch;
+            }
+            write("|");
+            if (heading != cx.tacobj.heading) {
+                write(sprintf("%.1f",heading));
+                cx.tacobj.heading = heading;
+            }
+            if (speed != cx.tacobj.speed) {
+                write(sprintf(",TAS=%.1f",speed));
+                cx.tacobj.speed = speed;
+            }
+            write("\n");
+        }
+        thread.unlock(mutexWrite);
+    }
+    explosion_timeout_loop();
+}
+
+var writeMyPlanePos = func() {
+    thread.lock(mutexWrite);
+    write(myplaneID ~ ",T=" ~ getLon() ~ "|" ~ getLat() ~ "|" ~ getAlt() ~ "|" ~ getRoll() ~ "|" ~ getPitch() ~ "|" ~ getHeading() ~ "\n");
+    thread.unlock(mutexWrite);
+}
+
+var writeMyPlaneAttributes = func() {
+    var tgt = "";
+    if(radar_system.apg68Radar.getPriorityTarget() != nil) {
+        tgt= ",FocusedTarget="~radar_system.apg68Radar.getPriorityTarget().tacobj.tacviewID;
+    }
+    var rmode = ",RadarMode=1";
+    if (getprop("sim/multiplay/generic/int[2]")) {
+        rmode = ",RadarMode=0";
+    }
+    var rrange = ",RadarRange="~rounder(getprop("instrumentation/radar/radar2-range")*NM2M,1);
+    var fuel = ",FuelWeight="~rounder(0.4535*getprop("/consumables/fuel/total-fuel-lbs"),1);
+    var gear = ",LandingGear="~rounder(getprop("gear/gear[0]/position-norm"),0.01);
+    var str = myplaneID ~ fuel~rmode~rrange~gear~",TAS="~getTas()~",CAS="~getCas()~",MACH="~getMach()~",AOA="~getAoA()~",HDG="~getHeading()~tgt~"\n";#",Throttle="~getThrottle()~",Afterburner="~getAfterburner()~
+    thread.lock(mutexWrite);
+    write(str);
+    thread.unlock(mutexWrite);
+}
+
+explo = {
+    tacviewID: 0,
+    time: 0,
+};
+
+var explo_arr = [];
+
+# needs threadlocked before calling
+var writeExplosion = func(lat,lon,altm,rad) {
+    var e = {parents:[explo]};
+    e.tacviewID = 21000 + int(math.floor(rand()*20000));
+    e.time = systime();
+    append(explo_arr, e);
+    write("#" ~ (systime() - starttime)~"\n");
+    write(e.tacviewID ~",T="~lon~"|"~lat~"|"~altm~",Radius="~rad~",Type=Explosion\n");
+}
+
+var explosion_timeout_loop = func(all = 0) {
+    foreach(var e; explo_arr) {
+        if (e.time) {
+            if (systime() - e.time > 15 or all) {
+                thread.lock(mutexWrite);
+                write("#" ~ (systime() - starttime)~"\n");
+                write("-"~e.tacviewID);
+                thread.unlock(mutexWrite);
+                e.time = 0;
+            }
+        }
+    }
+}
+
+var write = func(str) {
+    outstr = outstr ~ str;
+}
+
+var writetofile = func() {
+    if (outstr == "") {
+        return;
+    }
+    writetime = systime();
+    f = io.open(output_file, "a");
+    io.write(f, outstr);
+    io.close(f);
+    outstr = "";
+}
+
+var getLat = func() {
+    return getprop("/position/latitude-deg");
+}
+
+var getLon = func() {
+    return getprop("/position/longitude-deg");
+}
+
+var getAlt = func() {
+    return rounder(getprop("/position/altitude-ft") * FT2M,0.01);
+}
+
+var getRoll = func() {
+    return rounder(getprop("/orientation/roll-deg"),0.01);
+}
+
+var getPitch = func() {
+    return rounder(getprop("/orientation/pitch-deg"),0.01);
+}
+
+var getHeading = func() {
+    return rounder(getprop("/orientation/heading-deg"),0.01);
+}
+
+var getTas = func() {
+    return rounder(getprop("fdm/jsbsim/velocities/vtrue-kts") * KT2MPS,1.0);
+}
+
+var getCas = func() {
+    return rounder(getprop("fdm/jsbsim/velocities/vc-kts") * KT2MPS,1.0);
+}
+
+var getMach = func() {
+    return rounder(getprop("/velocities/mach"),0.001);
+}
+
+var getAoA = func() {
+    return rounder(getprop("/orientation/alpha-deg"),0.01);
+}
+
+#var getThrottle = func() {
+#    return rounder(getprop("velocities/thrust"),0.01);
+#}
+
+#var getAfterburner = func() {
+#    return getprop("velocities/thrust")>0.61*0.61;
+#}
+
+var rounder = func(x, p) {
+    v = math.mod(x, p);
+    if ( v <= (p * 0.5) ) {
+        x = x - v;
+    } else {
+        x = (x + p) - v;
+    }
+}
+
+var find_in_array = func(arr,val) {
+    forindex(var i; arr) {
+        if ( arr[i] == val ) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+#setlistener("/controls/armament/pickle", func() {
+#    if (!starttime) {
+#        return;
+#    }
+#    thread.lock(mutexWrite);
+#    write("#" ~ (systime() - starttime)~"\n");
+#    write("0,Event=Message|"~ myplaneID ~ "|Pickle, selection at " ~ (getprop("controls/armament/pylon-knob") + 1) ~ "\n");
+#    thread.unlock(mutexWrite);
+#},0,0);
+
+setlistener("/controls/armament/trigger", func(p) {
+    if (!starttime) {
+        return;
+    }
+    thread.lock(mutexWrite);
+    if (p.getValue()) {
+        write("#" ~ (systime() - starttime)~"\n");
+        write("0,Event=Message|"~ myplaneID ~ "|Trigger pressed.\n");
+    } else {
+        write("#" ~ (systime() - starttime)~"\n");
+        write("0,Event=Message|"~ myplaneID ~ "|Trigger released.\n");
+    }
+    thread.unlock(mutexWrite);
+},0,0);
+
+setlistener("/sim/multiplay/chat-history", func(p) {
+    if (!starttime) {
+        return;
+    }
+    var hist_vector = split("\n",p.getValue());
+    if (size(hist_vector) > 0) {
+        var last = hist_vector[size(hist_vector)-1];
+        last = string.replace(last,",",chr(92)~chr(44));#"\x5C"~"\x2C"
+        thread.lock(mutexWrite);
+        write("#" ~ (systime() - tacview.starttime)~"\n");
+        write("0,Event=Message|Chat ["~last~"]\n");
+        thread.unlock(mutexWrite);
+    }
+},0,0);
+
+
+var msg = func (txt) {
+    if (!starttime) {
+        return;
+    }
+    thread.lock(mutexWrite);
+    write("#" ~ (systime() - tacview.starttime)~"\n");
+    write("0,Event=Message|"~myplaneID~"|AI ["~txt~"]\n");
+    thread.unlock(mutexWrite);
+}
+
+setlistener("damage/sounds/explode-on", func(p) {
+    if (!starttime) {
+        return;
+    }
+
+    if (p.getValue()) {
+        thread.lock(mutexWrite);
+        write("#" ~ (systime() - tacview.starttime)~"\n");
+        write("0,Event=Destroyed|"~myplaneID~"\n");
+        thread.unlock(mutexWrite);
+    }
+},0,0);

--- a/libraries/tacview.nas
+++ b/libraries/tacview.nas
@@ -78,6 +78,29 @@ var heading = 0;
 var speed = 0;
 var mutexWrite = thread.newlock();
 
+var input = {
+    mp_host:    "sim/multiplay/txhost",
+    radar:      "sim/multiplay/generic/int[2]",
+    fuel:       "consumables/fuel/total-fuel-lbs",
+    gear:       "gear/gear[0]/position-norm",
+    lat:        "position/latitude-deg",
+    lon:        "position/longitude-deg",
+    alt:        "position/altitude-ft",
+    roll:       "orientation/roll-deg",
+    pitch:      "orientation/pitch-deg",
+    heading:    "orientation/heading-deg",
+    tas:        "fdm/jsbsim/velocities/vtrue-kts",
+    cas:        "velocities/airspeed-kt",
+    mach:       "velocities/mach",
+    aoa:        "orientation/alpha-deg",
+    gforce:     "accelerations/pilot-g",
+};
+
+foreach (var name; keys(input)) {
+    input[name] = props.globals.getNode(input[name], 1);
+}
+
+
 var startwrite = func() {
     if (starttime)
         return;
@@ -131,7 +154,7 @@ var mainloop = func() {
         if(cx.get_type() == armament.ORDNANCE) {
             continue;
         }
-        if (cx["prop"] != nil and cx.prop.getName() == "multiplayer" and getprop("sim/multiplay/txhost") == "mpserver.opredflag.com") {
+        if (cx["prop"] != nil and cx.prop.getName() == "multiplayer" and input.mp_host.getValue() == "mpserver.opredflag.com") {
             continue;
         }
         var color = ",Color=Blue";
@@ -215,7 +238,7 @@ var writeMyPlaneAttributes = func() {
         tgt= ",FocusedTarget="~contact.tacobj.tacviewID;
     }
     var rmode = ",RadarMode=1";
-    if (getprop("sim/multiplay/generic/int[2]")) {
+    if (input.radar.getBoolValue()) {
         rmode = ",RadarMode=0";
     }
     var rrange = get_radar_range_nm();
@@ -224,8 +247,8 @@ var writeMyPlaneAttributes = func() {
     } else {
         rrange = "";
     }
-    var fuel = ",FuelWeight="~math.round(0.4535*getprop("/consumables/fuel/total-fuel-lbs"),1);
-    var gear = ",LandingGear="~math.round(getprop("gear/gear[0]/position-norm"),0.01);
+    var fuel = ",FuelWeight="~math.round(0.4535*input.fuel.getValue(),1);
+    var gear = ",LandingGear="~math.round(input.gear.getValue(),0.01);
     var tas = getTas();
     if (tas != nil) {
         tas = ",TAS="~tas;
@@ -285,51 +308,51 @@ var writetofile = func() {
 }
 
 var getLat = func() {
-    return getprop("/position/latitude-deg");
+    return input.lat.getValue();
 }
 
 var getLon = func() {
-    return getprop("/position/longitude-deg");
+    return input.lon.getValue();
 }
 
 var getAlt = func() {
-    return math.round(getprop("/position/altitude-ft") * FT2M,0.01);
+    return math.round(input.alt.getValue() * FT2M,0.01);
 }
 
 var getRoll = func() {
-    return math.round(getprop("/orientation/roll-deg"),0.01);
+    return math.round(input.roll.getValue(),0.01);
 }
 
 var getPitch = func() {
-    return math.round(getprop("/orientation/pitch-deg"),0.01);
+    return math.round(input.pitch.getValue(),0.01);
 }
 
 var getHeading = func() {
-    return math.round(getprop("/orientation/heading-deg"),0.01);
+    return math.round(input.heading.getValue(),0.01);
 }
 
 var getTas = func() {
-    var tas = getprop("fdm/jsbsim/velocities/vtrue-kts");
+    var tas = input.tas.getValue();
     if (tas != nil)
-        return math.round(getprop("fdm/jsbsim/velocities/vtrue-kts") * KT2MPS,1.0);
+        return math.round(tas * KT2MPS,1.0);
     else
         return nil;
 }
 
 var getCas = func() {
-    return math.round(getprop("/velocities/airspeed-kt") * KT2MPS,1.0);
+    return math.round(input.cas.getValue() * KT2MPS,1.0);
 }
 
 var getMach = func() {
-    return math.round(getprop("/velocities/mach"),0.001);
+    return math.round(input.mach.getValue(),0.001);
 }
 
 var getAoA = func() {
-    return math.round(getprop("/orientation/alpha-deg"),0.01);
+    return math.round(input.aoa.getValue(),0.01);
 }
 
 var getG = func() {
-    getprop("accelerations/pilot-g");
+    return math.round(input.gforce.getValue(),0.01);
 }
 
 #var getThrottle = func() {

--- a/libraries/tacview.nas
+++ b/libraries/tacview.nas
@@ -3,6 +3,15 @@
 #
 # Authors: Pinto, Nikolai V. Chr., Colin Geniet
 
+# Short installation instructions:
+# - Add and load this file in the 'tacview' namespace.
+# - Adjust the four parameters just below.
+# - Set property /payload/d-config/tacview_supported=1
+# - Ensure the radar code sets 'tacobj' fields properly.
+#   In Nikolai/Richard generic 'radar-system.nas',
+#   this simply requires setting 'enable_tacobject=1'.
+# - Add some way to start/stop recording.
+
 ### Parameters to adjust (example values from the F-16)
 
 # Aircraft type string for tacview
@@ -31,6 +40,7 @@ var get_radar_range_nm = func {
 }
 
 ### End of parameters
+
 
 var main_update_rate = 0.3;
 var write_rate = 10;

--- a/libraries/tacview.nas
+++ b/libraries/tacview.nas
@@ -78,6 +78,9 @@ var speed = 0;
 var mutexWrite = thread.newlock();
 
 var startwrite = func() {
+    if (starttime)
+        return;
+
     timestamp = getprop("/sim/time/utc/year") ~ "-" ~ getprop("/sim/time/utc/month") ~ "-" ~ getprop("/sim/time/utc/day") ~ "T";
     timestamp = timestamp ~ getprop("/sim/time/utc/hour") ~ ":" ~ getprop("/sim/time/utc/minute") ~ ":" ~ getprop("/sim/time/utc/second") ~ "Z";
     var filetimestamp = string.replace(timestamp,":","-");

--- a/libraries/tacview.nas
+++ b/libraries/tacview.nas
@@ -207,7 +207,7 @@ var writeMyPlaneAttributes = func() {
     var rrange = ",RadarRange="~math.round(get_radar_range_nm()*NM2M,1);
     var fuel = ",FuelWeight="~math.round(0.4535*getprop("/consumables/fuel/total-fuel-lbs"),1);
     var gear = ",LandingGear="~math.round(getprop("gear/gear[0]/position-norm"),0.01);
-    var str = myplaneID ~ fuel~rmode~rrange~gear~",TAS="~getTas()~",CAS="~getCas()~",MACH="~getMach()~",AOA="~getAoA()~",HDG="~getHeading()~tgt~"\n";#",Throttle="~getThrottle()~",Afterburner="~getAfterburner()~
+    var str = myplaneID ~ fuel~rmode~rrange~gear~",TAS="~getTas()~",CAS="~getCas()~",Mach="~getMach()~",AOA="~getAoA()~",HDG="~getHeading()~tgt~"\n";#",Throttle="~getThrottle()~",Afterburner="~getAfterburner()~
     thread.lock(mutexWrite);
     write(str);
     thread.unlock(mutexWrite);

--- a/libraries/tacview.nas
+++ b/libraries/tacview.nas
@@ -226,7 +226,13 @@ var writeMyPlaneAttributes = func() {
     }
     var fuel = ",FuelWeight="~math.round(0.4535*getprop("/consumables/fuel/total-fuel-lbs"),1);
     var gear = ",LandingGear="~math.round(getprop("gear/gear[0]/position-norm"),0.01);
-    var str = myplaneID ~ fuel~rmode~rrange~gear~",TAS="~getTas()~",CAS="~getCas()~",Mach="~getMach()~",AOA="~getAoA()~",HDG="~getHeading()~tgt~",VerticalGForce="~getG()~"\n";#",Throttle="~getThrottle()~",Afterburner="~getAfterburner()~
+    var tas = getTas();
+    if (tas != nil) {
+        tas = ",TAS="~tas;
+    } else {
+        tas = "";
+    }
+    var str = myplaneID ~ fuel~rmode~rrange~gear~tas~",CAS="~getCas()~",Mach="~getMach()~",AOA="~getAoA()~",HDG="~getHeading()~tgt~",VerticalGForce="~getG()~"\n";#",Throttle="~getThrottle()~",Afterburner="~getAfterburner()~
     thread.lock(mutexWrite);
     write(str);
     thread.unlock(mutexWrite);
@@ -303,11 +309,15 @@ var getHeading = func() {
 }
 
 var getTas = func() {
-    return math.round(getprop("fdm/jsbsim/velocities/vtrue-kts") * KT2MPS,1.0);
+    var tas = getprop("fdm/jsbsim/velocities/vtrue-kts");
+    if (tas != nil)
+        return math.round(getprop("fdm/jsbsim/velocities/vtrue-kts") * KT2MPS,1.0);
+    else
+        return nil;
 }
 
 var getCas = func() {
-    return math.round(getprop("fdm/jsbsim/velocities/vc-kts") * KT2MPS,1.0);
+    return math.round(getprop("/velocities/airspeed-kt") * KT2MPS,1.0);
 }
 
 var getMach = func() {

--- a/libraries/tacview.nas
+++ b/libraries/tacview.nas
@@ -220,7 +220,7 @@ var writeMyPlaneAttributes = func() {
     var rrange = ",RadarRange="~math.round(get_radar_range_nm()*NM2M,1);
     var fuel = ",FuelWeight="~math.round(0.4535*getprop("/consumables/fuel/total-fuel-lbs"),1);
     var gear = ",LandingGear="~math.round(getprop("gear/gear[0]/position-norm"),0.01);
-    var str = myplaneID ~ fuel~rmode~rrange~gear~",TAS="~getTas()~",CAS="~getCas()~",Mach="~getMach()~",AOA="~getAoA()~",HDG="~getHeading()~tgt~"\n";#",Throttle="~getThrottle()~",Afterburner="~getAfterburner()~
+    var str = myplaneID ~ fuel~rmode~rrange~gear~",TAS="~getTas()~",CAS="~getCas()~",Mach="~getMach()~",AOA="~getAoA()~",HDG="~getHeading()~tgt~",VerticalGForce="~getG()~"\n";#",Throttle="~getThrottle()~",Afterburner="~getAfterburner()~
     thread.lock(mutexWrite);
     write(str);
     thread.unlock(mutexWrite);
@@ -310,6 +310,10 @@ var getMach = func() {
 
 var getAoA = func() {
     return math.round(getprop("/orientation/alpha-deg"),0.01);
+}
+
+var getG = func() {
+    getprop("accelerations/pilot-g");
 }
 
 #var getThrottle = func() {

--- a/libraries/tacview.nas
+++ b/libraries/tacview.nas
@@ -1,5 +1,7 @@
-# author: pinto
-# adapted by Nikolai V. Chr.
+# Copyright by Justin Nicholson (aka Pinto)
+# Released under the GNU General Public License version 2.0
+#
+# Authors: Pinto, Nikolai V. Chr., Colin Geniet
 
 var main_update_rate = 0.3;
 var write_rate = 10;

--- a/libraries/tacview.nas
+++ b/libraries/tacview.nas
@@ -114,7 +114,7 @@ var mainloop = func() {
     writeMyPlanePos();
     writeMyPlaneAttributes();
     foreach (var cx; get_contacts_list()) {
-        if(cx.getType() == armament.ORDNANCE) {
+        if(cx.get_type() == armament.ORDNANCE) {
             continue;
         }
         if (cx["prop"] != nil and cx.prop.getName() == "multiplayer" and getprop("sim/multiplay/txhost") == "mpserver.opredflag.com") {

--- a/libraries/tacview.nas
+++ b/libraries/tacview.nas
@@ -243,12 +243,12 @@ var writeMyPlaneAttributes = func() {
     }
     var rrange = get_radar_range_nm();
     if (rrange != nil) {
-        rrange = ",RadarRange="~math.round(get_radar_range_nm()*NM2M,1);
+        rrange = sprintf(",RadarRange=%.0f", get_radar_range_nm()*NM2M);
     } else {
         rrange = "";
     }
-    var fuel = ",FuelWeight="~math.round(0.4535*input.fuel.getValue(),1);
-    var gear = ",LandingGear="~math.round(input.gear.getValue(),0.01);
+    var fuel = sprintf(",FuelWeight=%.0f", input.fuel.getValue());
+    var gear = sprintf(",LandingGear=%.2f", input.gear.getValue());
     var tas = getTas();
     if (tas != nil) {
         tas = ",TAS="~tas;
@@ -316,47 +316,47 @@ var getLon = func() {
 }
 
 var getAlt = func() {
-    return math.round(input.alt.getValue() * FT2M,0.01);
+    return sprintf("%.2f", input.alt.getValue() * FT2M);
 }
 
 var getRoll = func() {
-    return math.round(input.roll.getValue(),0.01);
+    return sprintf("%.2f", input.roll.getValue());
 }
 
 var getPitch = func() {
-    return math.round(input.pitch.getValue(),0.01);
+    return sprintf("%.2f", input.pitch.getValue());
 }
 
 var getHeading = func() {
-    return math.round(input.heading.getValue(),0.01);
+    return sprintf("%.2f", input.heading.getValue());
 }
 
 var getTas = func() {
     var tas = input.tas.getValue();
     if (tas != nil)
-        return math.round(tas * KT2MPS,1.0);
+        return sprintf("%.1f", tas * KT2MPS);
     else
         return nil;
 }
 
 var getCas = func() {
-    return math.round(input.cas.getValue() * KT2MPS,1.0);
+    return sprintf("%.1f", input.cas.getValue() * KT2MPS);
 }
 
 var getMach = func() {
-    return math.round(input.mach.getValue(),0.001);
+    return sprintf("%.3f", input.mach.getValue());
 }
 
 var getAoA = func() {
-    return math.round(input.aoa.getValue(),0.01);
+    return sprintf("%.2f", input.aoa.getValue());
 }
 
 var getG = func() {
-    return math.round(input.gforce.getValue(),0.01);
+    return sprintf("%.2f", input.gforce.getValue());
 }
 
 #var getThrottle = func() {
-#    return math.round(getprop("velocities/thrust"),0.01);
+#    return sprintf("%.2f", getprop("velocities/thrust");
 #}
 
 #var getAfterburner = func() {

--- a/libraries/tacview.nas
+++ b/libraries/tacview.nas
@@ -44,7 +44,7 @@ var myplaneID = int(rand()*10000);
 var starttime = 0;
 var writetime = 0;
 
-seen_ids = [];
+var seen_ids = [];
 
 var tacobj = {
     tacviewID: 0,
@@ -70,7 +70,7 @@ var mutexWrite = thread.newlock();
 var startwrite = func() {
     timestamp = getprop("/sim/time/utc/year") ~ "-" ~ getprop("/sim/time/utc/month") ~ "-" ~ getprop("/sim/time/utc/day") ~ "T";
     timestamp = timestamp ~ getprop("/sim/time/utc/hour") ~ ":" ~ getprop("/sim/time/utc/minute") ~ ":" ~ getprop("/sim/time/utc/second") ~ "Z";
-    filetimestamp = string.replace(timestamp,":","-");
+    var filetimestamp = string.replace(timestamp,":","-");
     output_file = getprop("/sim/fg-home") ~ "/Export/tacview-" ~ filename_ac_type ~ "-" ~ filetimestamp ~ ".acmi";
     # create the file
     f = io.open(output_file, "w");
@@ -209,7 +209,7 @@ var writeMyPlaneAttributes = func() {
     thread.unlock(mutexWrite);
 }
 
-explo = {
+var explo = {
     tacviewID: 0,
     time: 0,
 };

--- a/libraries/tacview.nas
+++ b/libraries/tacview.nas
@@ -200,9 +200,9 @@ var writeMyPlaneAttributes = func() {
     if (getprop("sim/multiplay/generic/int[2]")) {
         rmode = ",RadarMode=0";
     }
-    var rrange = ",RadarRange="~rounder(get_radar_range_nm()*NM2M,1);
-    var fuel = ",FuelWeight="~rounder(0.4535*getprop("/consumables/fuel/total-fuel-lbs"),1);
-    var gear = ",LandingGear="~rounder(getprop("gear/gear[0]/position-norm"),0.01);
+    var rrange = ",RadarRange="~math.round(get_radar_range_nm()*NM2M,1);
+    var fuel = ",FuelWeight="~math.round(0.4535*getprop("/consumables/fuel/total-fuel-lbs"),1);
+    var gear = ",LandingGear="~math.round(getprop("gear/gear[0]/position-norm"),0.01);
     var str = myplaneID ~ fuel~rmode~rrange~gear~",TAS="~getTas()~",CAS="~getCas()~",MACH="~getMach()~",AOA="~getAoA()~",HDG="~getHeading()~tgt~"\n";#",Throttle="~getThrottle()~",Afterburner="~getAfterburner()~
     thread.lock(mutexWrite);
     write(str);
@@ -264,53 +264,44 @@ var getLon = func() {
 }
 
 var getAlt = func() {
-    return rounder(getprop("/position/altitude-ft") * FT2M,0.01);
+    return math.round(getprop("/position/altitude-ft") * FT2M,0.01);
 }
 
 var getRoll = func() {
-    return rounder(getprop("/orientation/roll-deg"),0.01);
+    return math.round(getprop("/orientation/roll-deg"),0.01);
 }
 
 var getPitch = func() {
-    return rounder(getprop("/orientation/pitch-deg"),0.01);
+    return math.round(getprop("/orientation/pitch-deg"),0.01);
 }
 
 var getHeading = func() {
-    return rounder(getprop("/orientation/heading-deg"),0.01);
+    return math.round(getprop("/orientation/heading-deg"),0.01);
 }
 
 var getTas = func() {
-    return rounder(getprop("fdm/jsbsim/velocities/vtrue-kts") * KT2MPS,1.0);
+    return math.round(getprop("fdm/jsbsim/velocities/vtrue-kts") * KT2MPS,1.0);
 }
 
 var getCas = func() {
-    return rounder(getprop("fdm/jsbsim/velocities/vc-kts") * KT2MPS,1.0);
+    return math.round(getprop("fdm/jsbsim/velocities/vc-kts") * KT2MPS,1.0);
 }
 
 var getMach = func() {
-    return rounder(getprop("/velocities/mach"),0.001);
+    return math.round(getprop("/velocities/mach"),0.001);
 }
 
 var getAoA = func() {
-    return rounder(getprop("/orientation/alpha-deg"),0.01);
+    return math.round(getprop("/orientation/alpha-deg"),0.01);
 }
 
 #var getThrottle = func() {
-#    return rounder(getprop("velocities/thrust"),0.01);
+#    return math.round(getprop("velocities/thrust"),0.01);
 #}
 
 #var getAfterburner = func() {
 #    return getprop("velocities/thrust")>0.61*0.61;
 #}
-
-var rounder = func(x, p) {
-    v = math.mod(x, p);
-    if ( v <= (p * 0.5) ) {
-        x = x - v;
-    } else {
-        x = (x + p) - v;
-    }
-}
 
 var find_in_array = func(arr,val) {
     forindex(var i; arr) {

--- a/libraries/tacview.nas
+++ b/libraries/tacview.nas
@@ -35,6 +35,7 @@ var get_primary_contact = func {
     return radar_system.apg68Radar.getPriorityTarget();
 }
 
+# Radar range. May return nil if n/a
 var get_radar_range_nm = func {
     return getprop("instrumentation/radar/radar2-range");
 }
@@ -217,7 +218,12 @@ var writeMyPlaneAttributes = func() {
     if (getprop("sim/multiplay/generic/int[2]")) {
         rmode = ",RadarMode=0";
     }
-    var rrange = ",RadarRange="~math.round(get_radar_range_nm()*NM2M,1);
+    var rrange = get_radar_range_nm();
+    if (rrange != nil) {
+        rrange = ",RadarRange="~math.round(get_radar_range_nm()*NM2M,1);
+    } else {
+        rrange = "";
+    }
     var fuel = ",FuelWeight="~math.round(0.4535*getprop("/consumables/fuel/total-fuel-lbs"),1);
     var gear = ",LandingGear="~math.round(getprop("gear/gear[0]/position-norm"),0.01);
     var str = myplaneID ~ fuel~rmode~rrange~gear~",TAS="~getTas()~",CAS="~getCas()~",Mach="~getMach()~",AOA="~getAoA()~",HDG="~getHeading()~tgt~",VerticalGForce="~getG()~"\n";#",Throttle="~getThrottle()~",Afterburner="~getAfterburner()~

--- a/libraries/tacview.nas
+++ b/libraries/tacview.nas
@@ -87,10 +87,11 @@ var startwrite = func() {
     thread.unlock(mutexWrite);
     starttime = systime();
     setprop("/sim/screen/black","Starting Tacview recording");
-    settimer(func(){mainloop();}, main_update_rate);
+    main_timer.start();
 }
 
 var stopwrite = func() {
+    main_timer.stop();
     setprop("/sim/screen/black","Stopping Tacview recording");
     writetofile();
     starttime = 0;
@@ -101,9 +102,9 @@ var stopwrite = func() {
 
 var mainloop = func() {
     if (!starttime) {
+        main_timer.stop();
         return;
     }
-    settimer(func(){mainloop();}, main_update_rate);
     if (systime() - writetime > write_rate) {
         writetofile();
     }
@@ -183,6 +184,9 @@ var mainloop = func() {
     }
     explosion_timeout_loop();
 }
+
+var main_timer = maketimer(main_update_rate, mainloop);
+
 
 var writeMyPlanePos = func() {
     thread.lock(mutexWrite);


### PR DESCRIPTION
Add the nasal tacview recorder to the libraries. This is the version from the F-16 repo, with a number of patches, most importantly:
- Regroup the aircraft-specific stuff in a few parameters at the top of the file. Hopefully it should be possible to port it to most aircrafts by only adjusting them.
- Add some porting instructions in the comments to go with that.
- Use yasim-compatible properties as much as possible. Tested with A-10.
- From Sammy on A-10: fixed `Mach` property name, and added G-force.
- And some programming nitpicking like `getprop`, `maketimer`, etc. because I'm a nerd.

I think all aircrafts except the MiG should be able to switch to this version with minimal work (namely adjusting the 5 parameters).
The MiG tacview recorder has significantly diverged from the F-16 version. I haven't merged the two versions.

There's also a very small change to `missile-code.nas`: it, and `damage.nas` were checking different properties to know if tacview is enabled, which seems silly.