### PR TITLE
station-manager stuff from the Viggen

### DIFF
--- a/libraries/station-manager.nas
+++ b/libraries/station-manager.nas
@@ -583,7 +583,15 @@ var Pylon = {
 
 	setGUI: func {
 		me.nameGUI = "";
-		if (me.currentSet.showLongTypeInsteadOfCount) {
+		if (me.currentSet.showNameInsteadOfCount) {
+			# Only check that something is loaded
+			foreach(me.wapny;me.weapons) {
+				if (me.wapny != nil) {
+					me.nameGUI = me.currentSet.name;
+					break;
+				}
+			}
+		} elsif (me.currentSet.showLongTypeInsteadOfCount) {
 			foreach(me.wapny;me.weapons) {
 				if (me.wapny != nil) {
 					me.nameGUI = me.wapny.typeLong;
@@ -637,7 +645,7 @@ var Pylon = {
 
 	getCurrentShortName: func {
 		me.nameS = "";
-		if (me.currentSet.showLongTypeInsteadOfCount) {
+		if (me.currentSet.showNameInsteadOfCount or me.currentSet.showLongTypeInsteadOfCount) {
 			foreach(me.wapny;me.weapons) {
 				if (me.wapny != nil) {
 					me.nameS = me.wapny.typeShort;
@@ -886,7 +894,7 @@ var WPylon = {
 	
 	getCurrentSMSName: func {
 		me.nameS = "";
-		if (me.currentSet.showLongTypeInsteadOfCount) {
+		if (me.currentSet.showNameInsteadOfCount or me.currentSet.showLongTypeInsteadOfCount) {
 			foreach(me.wapny;me.weapons) {
 				if (me.wapny != nil) {
 					me.nameS = me.wapny.typeShort;

--- a/libraries/station-manager.nas
+++ b/libraries/station-manager.nas
@@ -583,7 +583,7 @@ var Pylon = {
 
 	setGUI: func {
 		me.nameGUI = "";
-		if (me.currentSet.showNameInsteadOfCount) {
+		if (me.currentSet["showNameInsteadOfCount"]) {
 			# Only check that something is loaded
 			foreach(me.wapny;me.weapons) {
 				if (me.wapny != nil) {
@@ -591,7 +591,7 @@ var Pylon = {
 					break;
 				}
 			}
-		} elsif (me.currentSet.showLongTypeInsteadOfCount) {
+		} elsif (me.currentSet["showLongTypeInsteadOfCount"]) {
 			foreach(me.wapny;me.weapons) {
 				if (me.wapny != nil) {
 					me.nameGUI = me.wapny.typeLong;
@@ -645,7 +645,7 @@ var Pylon = {
 
 	getCurrentShortName: func {
 		me.nameS = "";
-		if (me.currentSet.showNameInsteadOfCount or me.currentSet.showLongTypeInsteadOfCount) {
+		if (me.currentSet["showNameInsteadOfCount"] or me.currentSet["showLongTypeInsteadOfCount"]) {
 			foreach(me.wapny;me.weapons) {
 				if (me.wapny != nil) {
 					me.nameS = me.wapny.typeShort;
@@ -681,7 +681,7 @@ var Pylon = {
 	
 	getCurrentSMSName: func {
 		me.nameS = "";
-		if (me.currentSet.showLongTypeInsteadOfCount) {
+		if (me.currentSet["showLongTypeInsteadOfCount"]) {
 			foreach(me.wapny;me.weapons) {
 				if (me.wapny != nil) {
 					if (me.wapny.typeShort != nil) {
@@ -858,7 +858,7 @@ var WPylon = {
 
 	getCurrentShortName: func {
 		me.nameS = "";
-		if (me.currentSet.showLongTypeInsteadOfCount) {
+		if (me.currentSet["showLongTypeInsteadOfCount"]) {
 			foreach(me.wapny;me.weapons) {
 				if (me.wapny != nil) {
 					me.nameS = me.wapny.typeShort;
@@ -894,7 +894,7 @@ var WPylon = {
 	
 	getCurrentSMSName: func {
 		me.nameS = "";
-		if (me.currentSet.showNameInsteadOfCount or me.currentSet.showLongTypeInsteadOfCount) {
+		if (me.currentSet["showNameInsteadOfCount"] or me.currentSet["showLongTypeInsteadOfCount"]) {
 			foreach(me.wapny;me.weapons) {
 				if (me.wapny != nil) {
 					me.nameS = me.wapny.typeShort;

--- a/libraries/station-manager.nas
+++ b/libraries/station-manager.nas
@@ -300,6 +300,10 @@ var Station = {
 		}
 	},
 
+	reloadCurrentSet: func {
+		me.loadSet(me.currentSet);
+	},
+
 	loadingSet: func (set) {
 		# Override this function. Gets called after a set is loaded, but before any mass, fdm, gui settings is applied.
 	},

--- a/libraries/station-manager.nas
+++ b/libraries/station-manager.nas
@@ -990,13 +990,14 @@ var SubModelWeapon = {
 #
 # Attributes:
 #  drag, weight, submodel(s)
-	new: func (name, munitionMass, maxAmmo, subModelNumbers, tracerSubModelNumbers, trigger, jettisonable, operableFunction=nil, alternate = 0) {
+	new: func (name, munitionMass, maxAmmo, subModelNumbers, tracerSubModelNumbers, trigger, jettisonable, operableFunction=nil, alternate=0, podSubModelNumbers=nil, podSubModelTrigger=nil) {
 		var s = {parents:[SubModelWeapon]};
 		s.type = name;
 		s.typeLong = name;
 		s.typeShort = name;
 		s.subModelNumbers = subModelNumbers;
 		s.tracerSubModelNumbers = tracerSubModelNumbers;
+		s.podSubModelNumbers = podSubModelNumbers;
 		s.operableFunction = operableFunction;
 		s.maxAmmo = maxAmmo;
 		s.munitionMass = munitionMass;
@@ -1004,6 +1005,7 @@ var SubModelWeapon = {
 		s.weight_launch_lbm = 0;
 		s.trigger = trigger;
 		s.triggerNode = nil;
+		s.podSubModelTrigger = podSubModelTrigger;
 		s.active = 0;
 		s.alternate = alternate;
 		s.timer = nil;
@@ -1057,6 +1059,7 @@ var SubModelWeapon = {
 
 	mount: func(pylon) {
 		me.reloadAmmo();
+		me.loadPodSubModels(1);
 		#if (me.timer != nil and me.timer.isRunning) me.timer.stop();
 		#me.timer = nil;
 		me.timer = 1;#maketimer(0.1, me, func me.loop());
@@ -1073,6 +1076,7 @@ var SubModelWeapon = {
 			me.timer = nil;
 			me.trigger.unalias();
 			me.trigger.setBoolValue(0);
+			me.ejectPodSubModels();
 		}
 	},
 
@@ -1081,6 +1085,7 @@ var SubModelWeapon = {
 		me.timer = nil;
 		me.trigger.unalias();
 		me.trigger.setBoolValue(0);
+		me.loadPodSubModels(0);
 	},
 
 	getAmmo: func () {
@@ -1096,6 +1101,22 @@ var SubModelWeapon = {
 		for(me.i = 0;me.i<size(me.subModelNumbers);me.i+=1) {
 			setprop("ai/submodels/submodel["~me.subModelNumbers[me.i]~"]/count", me.maxAmmo);
 		}
+	},
+
+	loadPodSubModels: func(count) {
+		if (me.podSubModelNumbers == nil) return;
+		foreach(me.submodel; me.podSubModelNumbers) {
+			setprop("ai/submodels/submodel["~me.submodel~"]/count", count);
+		}
+	},
+
+	ejectPodSubModels: func {
+		if (me.podSubModelTrigger == nil) return;
+
+		me.podSubModelTrigger.setBoolValue(1);
+		me.podTimer = maketimer(0, me, func { me.podSubModelTrigger.setBoolValue(0); });
+		me.podTimer.singleShot = 1;
+		me.podTimer.start();
 	},
 };
 

--- a/versions.json
+++ b/versions.json
@@ -28,7 +28,7 @@
     "path": "libraries/datalink.nas"
   },
   "station-manager": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "path": "libraries/station-manager.nas"
   },
   "rcs-mand": {


### PR DESCRIPTION
A few extra features for pylons which I've been using in the Viggen for some time:
- submodels to animate pod jettison,
- a function to reload whatever was last loaded,
- and yet another naming scheme for the loadout options list in the GUI