### PR TITLE
Add missing copyright file. It also clarifies that it is GPL 2+.

### DIFF
--- a/copyright.txt
+++ b/copyright.txt
@@ -1,0 +1,17 @@
+This copyright notice extends to all files in this repository.
+
+Copyright (C) 2024
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.


### PR DESCRIPTION
Please note that many of the files in this repo already come from GPL 2+ aircraft so by effect it already is GPL 2+, this notice was just missing.

Pinging some people, please reply to this PR if you disagree with this PR.

@l0k1 
@JMaverick16 
@Zaretto 
@colingeniet
@SammySkycrafts
@BobDotCom