### PR TITLE
Fix MP ignore for FG 2024

### DIFF
--- a/assets/fire-control.nas
+++ b/assets/fire-control.nas
@@ -172,7 +172,7 @@ var scan = func() {
 		foreach(var mp; mvec){
 			if (mp.getNode("valid") == nil or mp.getNode("valid").getValue() != 1) continue;
 			if (mp.getNode("callsign") == nil or mp.getNode("callsign").getValue() == nil
-			 or multiplayer.ignore[mp.getNode("callsign").getValue()] == 1) continue;
+			 or damage.isIgnoredNode(mp)) continue;
 			var prio = fire_control(mp, my_pos);
 			append(prio_vector, prio);
 			if (prio[3] == 1) {

--- a/emesary-damage-system/nasal/missile-code.nas
+++ b/emesary-damage-system/nasal/missile-code.nas
@@ -5043,7 +5043,7 @@ var AIM = {
 
 	goToLock: func {
         me.callsign = damage.processCallsign(me.tagt.get_Callsign());
-        if (multiplayer.ignore[me.callsign] == 1) {
+		if (damage.isIgnoredCallsign(me.callsign)) {
         	me.callsign = "Unknown";
         	if (me.tagt == contact) contact = nil;
         	makesettimer(func me.search(), 0.1);

--- a/libraries/datalink.nas
+++ b/libraries/datalink.nas
@@ -452,9 +452,8 @@ var receive_loop = func {
         if (!mp.getValue("valid")) continue;
         var callsign = mp.getValue("callsign");
         if (callsign == nil) continue;
-        if(multiplayer.ignore[callsign] == 1) {
-            continue;
-        }
+        if (damage.isIgnoredNode(mp)) continue;
+
         callsign_to_index[callsign] = idx;
 
         var data = mp.getValue(mp_path);

--- a/radar/radar-system.nas
+++ b/radar/radar-system.nas
@@ -252,7 +252,7 @@ var AIToNasal = {
         } else {
         	me.callsign = me.callsign.getValue();
         }
-        if(me.callsign != nil and multiplayer.ignore[me.callsign] == 1) {
+        if(damage.isIgnoredNode(me.prop_ai)) {
         	me.nextReadTreeFrame();
 		    return;
 		}

--- a/versions.json
+++ b/versions.json
@@ -4,11 +4,11 @@
     "path": "emesary-damage-system/nasal/vector.nas"
   },
   "missile-code": {
-    "version": "1.2.0",
+    "version": "1.2.1",
     "path": "emesary-damage-system/nasal/missile-code.nas"
   },
   "radar-system": {
-    "version": "2.0.7",
+    "version": "2.0.8",
     "path": "radar/radar-system.nas"
   },
   "radar-system-database": {
@@ -16,7 +16,7 @@
     "path": "radar/radar-system-database.nas"
   },
   "damage": {
-    "version": "1.4.13",
+    "version": "1.4.14",
     "path": "emesary-damage-system/nasal/damage.nas"
   },
   "iff": {
@@ -24,7 +24,7 @@
     "path": "libraries/iff.nas"
   },
   "datalink": {
-    "version": "1.1.1",
+    "version": "1.1.2",
     "path": "libraries/datalink.nas"
   },
   "station-manager": {
@@ -64,7 +64,7 @@
     "path": "libraries/airbases.xml"
   },
   "asset-fire-control": {
-    "version": "1.0.3",
+    "version": "1.0.4",
     "path": "assets/fire-control.nas"
   },
   "asset-radar-logic": {


### PR DESCRIPTION
multiplayer.ignore no longer exists in FG next
(fgdata commit 26231587b Convert multiplayer pilot list to Canvas, 2024-02-28)

Add helpers isIgnoredCallsign and isIgnoredNode in damage.nas to handle ignore test for all FG versions.
Convert all damage/radar code to use these.

Tested with FG next and FG 2020.3.19 (except the `assets/fire-controls.nas` part)